### PR TITLE
Update Debian and Postgresql URL installation

### DIFF
--- a/infrastructure/bastion/Dockerfile
+++ b/infrastructure/bastion/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-stretch
 
 ## Installing clients
 RUN  sh -c "echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list" && \

--- a/infrastructure/bastion/Dockerfile
+++ b/infrastructure/bastion/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6
 
 ## Installing clients
-RUN  sh -c "echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' > /etc/apt/sources.list.d/pgdg.list" && \
+RUN  sh -c "echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list" && \
      wget --quiet -O - http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add - && \
      apt-get -y update && \
      apt-get -y install less postgresql-9.6-postgis-2.2 \

--- a/infrastructure/bastion/requirements.txt
+++ b/infrastructure/bastion/requirements.txt
@@ -10,7 +10,6 @@ scikit-learn
 ipython
 jupyter
 pgcli
-prompt_toolkit
 rq
 
 ## DSaPP stuff

--- a/infrastructure/bastion/requirements.txt
+++ b/infrastructure/bastion/requirements.txt
@@ -13,4 +13,4 @@ pgcli
 rq
 
 ## DSaPP stuff
-git+https://github.com/dssg/triage.git@v3.beta
+git+https://github.com/dssg/triage.git

--- a/infrastructure/triage/requirements.txt
+++ b/infrastructure/triage/requirements.txt
@@ -12,4 +12,4 @@ pydotplus
 rq
 
 ## DSaPP stuff
-git+https://github.com/dssg/triage.git@v3.beta
+git+https://github.com/dssg/triage.git

--- a/triage/experiment_config/inspections_baseline.yaml
+++ b/triage/experiment_config/inspections_baseline.yaml
@@ -85,7 +85,7 @@ feature_group_strategies: ['all']
 
 scoring:
     sort_seed: 5
-    metric_groups:
+    testing_metric_groups:
         -
           metrics: [precision@, recall@]
           thresholds:

--- a/triage/experiment_config/simple_test_skeleton.yaml
+++ b/triage/experiment_config/simple_test_skeleton.yaml
@@ -135,7 +135,7 @@ feature_group_strategies: ['all']
 
 scoring:
    sort_seed: 5
-   metric_groups:
+   testing_metric_groups:
        -
           metrics: ['precision@', 'recall@']
           thresholds:


### PR DESCRIPTION
This PR adds: 
- Updated Debian container `python3.6-stretch` by default, and compatible with the last version from PostgreSQL. 
- Remove python conflicting libraries to use `ipython` and `jupyter` without any issues. 
- Update configuration files for experiments with the latest structure in `triage` (metrics per training and testing groups).